### PR TITLE
fix: fixes deployment.yaml template rendering

### DIFF
--- a/charts/pod-image-swap-webhook/templates/deployment.yaml
+++ b/charts/pod-image-swap-webhook/templates/deployment.yaml
@@ -1,9 +1,9 @@
+{{- if eq .Values.kind "Deployment" -}}
 #trivy:ignore:avd-ksv-0032
 #trivy:ignore:avd-ksv-0033
 #trivy:ignore:avd-ksv-0034
 #trivy:ignore:avd-ksv-0035
 #trivy:ignore:avd-ksv-0125
-{{- if eq .Values.kind "Deployment" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Currently when using Deployment mode the deployment.yaml tepmlate gets rendered badly because of the trivy ignore lines

 Source: pod-image-swap-webhook/templates/deployment.yaml
trivy:ignore:avd-ksv-0032
trivy:ignore:avd-ksv-0033
trivy:ignore:avd-ksv-0034
trivy:ignore:avd-ksv-0035
trivy:ignore:avd-ksv-0125apiVersion: apps/v1

This puts the trivy lines inside the if statement